### PR TITLE
Fix crash bug of not having init(layer:) overriden method

### DIFF
--- a/Ripple-Animation/.gitignore
+++ b/Ripple-Animation/.gitignore
@@ -1,0 +1,2 @@
+Ripple-Animation.xcodeproj/project.xcworkspace/xcuserdata/
+Ripple-Animation.xcodeproj/xcuserdata/

--- a/Ripple-Animation/Ripple-Animation.xcodeproj/project.pbxproj
+++ b/Ripple-Animation/Ripple-Animation.xcodeproj/project.pbxproj
@@ -99,7 +99,7 @@
 				TargetAttributes = {
 					4F1256981E1EEE3300C1FCBA = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = R9N46X69BX;
+						DevelopmentTeam = XGKHW634KL;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -263,7 +263,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = R9N46X69BX;
+				DEVELOPMENT_TEAM = XGKHW634KL;
 				INFOPLIST_FILE = "Ripple-Animation/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nikita.Ripple-Animation";
@@ -276,7 +276,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = R9N46X69BX;
+				DEVELOPMENT_TEAM = XGKHW634KL;
 				INFOPLIST_FILE = "Ripple-Animation/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nikita.Ripple-Animation";
@@ -304,6 +304,7 @@
 				4F1256AD1E1EEE3300C1FCBA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Ripple-Animation/Ripple-Animation/RippleLayer.swift
+++ b/Ripple-Animation/Ripple-Animation/RippleLayer.swift
@@ -21,6 +21,13 @@ class RippleLayer: CAReplicatorLayer {
 		
 		repeatCount = Float(rippleRepeatCount)
 	}
+    
+    override init(layer: Any) {
+        super.init(layer: layer)
+        setupRippleEffect()
+        
+        repeatCount = Float(rippleRepeatCount)
+    }
 	
 	required init?(coder aDecoder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
In certain case as tested on my side, not having overriden method of `init(layer:)` causes the crash. This patch fixed this.